### PR TITLE
Use full_description for generating the file name

### DIFF
--- a/lib/vcr_assistant/file_name.rb
+++ b/lib/vcr_assistant/file_name.rb
@@ -16,7 +16,7 @@ class VCRAssistant::FileName
   attr_reader :example
 
   def file
-    example.metadata[:description].downcase.gsub(/\s+/, '_').gsub(/[\W]+/, '')
+    example.metadata[:full_description].downcase.gsub(/\s+/, '_').gsub(/[\W]+/, '')
   end
 
   def folder


### PR DESCRIPTION
The previous implementation did not take contexts/etc into consideration, so you may end up with multiple specs writing to the same `.yaml` file. (especially when using RSpec "shared examples", where the spec names can be the same but in different context).
