### PR TITLE
Travis: update Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.11.2
+  - 2.2.7
+before_install:
+  - gem install bundler


### PR DESCRIPTION
This PR touches the Travis CI configuration, which forces a build.

- Bundler has newer versions
- Ruby has newer versions of the 2.2 series.